### PR TITLE
服务器上部署时文件访问地址错误

### DIFF
--- a/app.py
+++ b/app.py
@@ -135,7 +135,7 @@ def tts():
         combined_wavdata = np.concatenate((combined_wavdata, wavdata[0]))
 
     sf.write(WAVS_DIR+'/'+filename, combined_wavdata, 24000)
-    return jsonify({"code": 0, "msg": "ok","filename":WAVS_DIR+'/'+filename,"url":f"http://{WEB_ADDRESS}/static/wavs/{filename}"})
+    return jsonify({"code": 0, "msg": "ok","filename":WAVS_DIR+'/'+filename,"url":f"http://{request.host}/static/wavs/{filename}"})
 
 
 


### PR DESCRIPTION
138行处不应使用WEB_ADDRESS，在服务器上部署时配置访问地址为0.0.0.0时，回包的文件url地址有误，可用使用客户端的请求地址来处理