### PR TITLE
修复使用huggingface下载模型时CHATTTS_DIR没被定义的问题

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,11 +39,13 @@ chat.load_models(source="local",local_path=CHATTTS_DIR, compile=True if os.geten
 
 # 如果希望从 huggingface.co下载模型，将以下注释删掉。将上方3行内容注释掉
 
+# import huggingface_hub
+# os.environ['HF_HUB_CACHE']=MODEL_DIR
+# os.environ['HF_ASSETS_CACHE']=MODEL_DIR
+# CHATTTS_DIR = huggingface_hub.snapshot_download(cache_dir=MODEL_DIR,repo_id="2Noise/ChatTTS", allow_patterns=["*.pt", "*.yaml"])
 # chat = ChatTTS.Chat()
-# chat.load_models(compile=True if os.getenv('compile','true').lower()!='false' else False)
-# hf_home= os.getenv('HF_HOME', os.path.expanduser("~/.cache/huggingface"))
-# from ChatTTS.utils.io_utils import get_latest_modified_file
-# CHATTTS_DIR = get_latest_modified_file(os.path.join(hf_home, 'hub/models--2Noise--ChatTTS/snapshots'))
+# chat.load_models(source="local",local_path=CHATTTS_DIR, compile=True if os.getenv('compile','true').lower()!='false' else False)
+
 
 
 

--- a/app.py
+++ b/app.py
@@ -38,10 +38,12 @@ chat = ChatTTS.Chat()
 chat.load_models(source="local",local_path=CHATTTS_DIR, compile=True if os.getenv('compile','true').lower()!='false' else False)
 
 # 如果希望从 huggingface.co下载模型，将以下注释删掉。将上方3行内容注释掉
-#os.environ['HF_HUB_CACHE']=MODEL_DIR
-#os.environ['HF_ASSETS_CACHE']=MODEL_DIR
-#chat = ChatTTS.Chat()
-#chat.load_models(compile=True if os.getenv('compile','true').lower()!='false' else False)
+
+# chat = ChatTTS.Chat()
+# chat.load_models(compile=True if os.getenv('compile','true').lower()!='false' else False)
+# hf_home= os.getenv('HF_HOME', os.path.expanduser("~/.cache/huggingface"))
+# from ChatTTS.utils.io_utils import get_latest_modified_file
+# CHATTTS_DIR = get_latest_modified_file(os.path.join(hf_home, 'hub/models--2Noise--ChatTTS/snapshots'))
 
 
 


### PR DESCRIPTION
从 huggingface.co下载模型时，CHATTTS_DIR没有被定义。并且环境变量好像也没切成功（可能是我的环境问题），模型还是下载到了默认的文件夹中。我参照ChatTTS.core.Chat.load_models的逻辑重写了这段代码。