### PR TITLE
Update requirements.txt: fix transformers version mismatch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ python-dotenv
 requests
 soundfile
 tokenizers
-transformers>=4.41.1
+transformers==4.41.1
 vector-quantize-pytorch
 vocos
 waitress


### PR DESCRIPTION
Fix the error traceback that ended with:
```
File "D:\chattts\ChatTTS\model\tokenizer.py", line 59, in encode
    x = self._tokenizer.encode_plus(
File "xxxlocalpathxxx\Python310\site-packages\transformers\tokenization_utils_base.py", line 3037, in encode_plus
    padding_strategy, truncation_strategy, max_length, kwargs = self._get_padding_truncation_strategies(
File "xxxlocalpathxxx\Python310\site-packages\transformers\tokenization_utils_base.py", line 2761, in _get_padding_truncation_strategies
    if padding_strategy != PaddingStrategy.DO_NOT_PAD and (self.pad_token is None or self.pad_token_id < 0):
File "xxxlocalpathxxx\Python310\site-packages\transformers\tokenization_utils_base.py", line 1104, in __getattr__
    raise AttributeError(f"{self.__class__.__name__} has no attribute {key}")
AttributeError: BertTokenizerFast has no attribute pad_token
```
生成voice时必现，'pip install transformers==4.41.1'后不再出现